### PR TITLE
Fix padding on post elements

### DIFF
--- a/basic.css
+++ b/basic.css
@@ -160,6 +160,7 @@ textarea {
   text-align: left;
   width: 100%;
   padding: 10px;
+  box-sizing: border-box;
   border-bottom: 1px solid gray;
   background-color: lightgray;
 }
@@ -177,6 +178,7 @@ textarea {
   text-align: left;
   width: 100%;
   padding: 10px;
+  box-sizing: border-box;
   background-color: white;
 }
 


### PR DESCRIPTION
Before:

![Before screenshot](https://cloud.githubusercontent.com/assets/9948030/26512196/e20c96f0-423b-11e7-887b-67a5e77530c4.png)

Note that letters are cut off. This is due to bad box sizing:

![Box width is too large](https://cloud.githubusercontent.com/assets/9948030/26512214/f84b3624-423b-11e7-88f0-8396aab3eeeb.png)

This PR adds `box-sizing: border-box`, which fixes this issue. After this PR:

![After screenshot](https://cloud.githubusercontent.com/assets/9948030/26512255/27027252-423c-11e7-8d13-6530c3cbe6c8.png)

![Box width is correct](https://cloud.githubusercontent.com/assets/9948030/26512265/3107bf5a-423c-11e7-9754-b0c23c1b06f8.png)

This PR also fixes the float-right text (i.e. "# replies") in post headers being cut off; it was caused by essentially the same issue (bad box sizing).

![Before screenshot of post on post index](https://cloud.githubusercontent.com/assets/9948030/26512309/59a73756-423c-11e7-8309-3054a9081025.png)
