### PR TITLE
Put initializing PHP at the beginning of the header.php file

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,13 +1,13 @@
-<head>
-  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="basic.css?<?php echo date('l jS \of F Y h:i:s A'); ?>">
-  <title>AT Challenges</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
 <?php
 ini_set('display_errors', 1);
 error_reporting(~0);
 session_start();
  ?>
+<head>
+  <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+  <link rel="stylesheet" type="text/css" href="basic.css?<?php echo date('l jS \of F Y h:i:s A'); ?>">
+  <title>AT Challenges</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
   <div class='nav'>


### PR DESCRIPTION
Putting the initialization PHP code at the absolute beginning of the header.php file – that is, before any HTML content is sent to the user – helps to fix warnings such as this one from appearing:

![Cannot send cache delimiter - headers already sent](https://cloud.githubusercontent.com/assets/9948030/26512521/61b7ed86-423d-11e7-823c-d3e76862a547.png)

See also: [How to fix "Headers already sent" error in PHP](https://stackoverflow.com/a/8028979/4633828)
